### PR TITLE
当存在 path 变量时, 会import  net/url, 但是只有string等个别类型才会用到 url包

### DIFF
--- a/internal/gengapic/generator.go
+++ b/internal/gengapic/generator.go
@@ -256,6 +256,13 @@ func (g *generator) commit(fileName, pkgName string) int {
 	}
 	header.WriteString(")\n\n")
 	lineCount := len(strings.Split(header.String(), "\n"))
+
+	for _, imp := range imps {
+		if imp.Path == "net/url" {
+			header.WriteString("type _ url.Values\n\n")
+		}
+	}
+
 	g.resp.File = append(g.resp.File, &pluginpb.CodeGeneratorResponse_File{
 		Name:    &fileName,
 		Content: proto.String(header.String()),


### PR DESCRIPTION
    option (google.api.http) = {
      post: "/api/v1/esign/tx/{provider_id}:callback",
      body: "*"
    };